### PR TITLE
Fix: Properly await main() coroutine to prevent RuntimeWarning

### DIFF
--- a/src/mcp_server_things3/server.py
+++ b/src/mcp_server_things3/server.py
@@ -434,8 +434,8 @@ async def handle_call_tool(
         logger.error(f"Error handling tool {name}: {e}")
         return [types.TextContent(type="text", text=f"Error: {str(e)}")]
 
-async def main():
-    """Run the server."""
+async def async_main():
+    """Run the server asynchronously."""
     logger.info("Starting Things3 MCP server...")
     
     # Handle graceful shutdown
@@ -469,5 +469,10 @@ async def main():
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
 
+def main():
+    """Entry point for the MCP server."""
+    asyncio.run(async_main())
+
+
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
## Summary
- Fixed startup crash caused by calling async `main()` without `asyncio.run()`
- The `[project.scripts]` entry point was invoking the coroutine directly, causing "coroutine was never awaited" errors

## Changes
- Renamed `async def main()` → `async def async_main()`
- Added synchronous `def main()` wrapper that calls `asyncio.run(async_main())`

## Test
Server now starts correctly on Python 3.13+:
```
INFO:mcp_server_things3.server:Starting Things3 MCP server...
```

No more `RuntimeWarning: coroutine 'main' was never awaited` error.

Fixes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored application startup flow to introduce a synchronous entry wrapper around the async startup path, improving launch reliability and alignment with common execution patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->